### PR TITLE
Avoid duplicate package declaration in ceph::rgw

### DIFF
--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -78,10 +78,10 @@ define ceph::rgw (
     "client.${name}/user":               value => $user;
   }
 
-  package { $pkg_radosgw:
+  ensure_resource('package', $pkg_radosgw, {
     ensure => installed,
     tag    => 'ceph',
-  }
+  })
 
   # Data directory for radosgw
   file { '/var/lib/ceph/radosgw': # missing in redhat pkg


### PR DESCRIPTION
Defining two or more ceph::rgw resources would lead to duplicate package declarations.
